### PR TITLE
Add play count to asset interface

### DIFF
--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -57,6 +57,7 @@ export interface IAsset {
   contract_address: string;
   creator_address: string;
   creator_name: string;
+  play_count: number;
   deployment_metadata: {
     grant_ttl_seconds: number;
     price_per_access_usd: number;


### PR DESCRIPTION
@un7c0rn once you shared the RPC that returns a dict with a key of `play_count`, I realized I had the asset streams all along when I was fetching uploads via `listAssetsByCreator`.