### PR TITLE
Add splits interfaces

### DIFF
--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -69,3 +69,23 @@ export interface IAsset {
     };
   };
 }
+
+export interface ISplitsData {
+  total_slots: string;
+  total_splits: number;
+  community_allocation_percent: number;
+  percent_per_slot: number;
+  splits_data: {
+    wallet_address: string;
+    unique_id: string;
+    display_name: string | null;
+    percentage: number;
+  }[];
+}
+
+export interface ISplit {
+  display_name: string | null;
+  percentage: number;
+  unique_id: string | null;
+  wallet_address: string;
+}


### PR DESCRIPTION
Adds interfaces used to define the RPC response of `fetchSplitsData()` and an individual split's details.