### PR TITLE
encapsulate credential data

### DIFF
--- a/src/lib/Credential.ts
+++ b/src/lib/Credential.ts
@@ -18,7 +18,7 @@ export class PlatformAuthenticatorCredential
     platformAuthenticatorClientDataBase64: string,
     platformAuthenticatorSignatureBase64: string
   ) {
-    this.credentialType = "PlatformAuthenticatorCredential";
+    this.credentialType = "platform_authenticator_credential";
     this.platformAuthenticatorDataBase64 =
       platformAuthenticatorDataBase64;
     this.platformAuthenticatorClientDataBase64 =
@@ -72,7 +72,7 @@ export class GoogleOAuth2Credential
     googleOAuth2CredentialClientID: string,
     googleOAuth2CredentialJWT: string
   ) {
-    this.credentialType = "GoogleOAuth2Credential";
+    this.credentialType = "google_oauth2_credential";
     this.googleOAuth2CredentialClientID =
       googleOAuth2CredentialClientID;
     this.googleOAuth2CredentialJWT = googleOAuth2CredentialJWT;

--- a/src/lib/Credential.ts
+++ b/src/lib/Credential.ts
@@ -1,0 +1,107 @@
+import {
+  IGoogleOAuth2Credential,
+  IPlatformAuthenticatorCredential,
+  ISerializable,
+} from "./Interfaces";
+import { Dictionary } from "./Types";
+
+export class PlatformAuthenticatorCredential
+  implements IPlatformAuthenticatorCredential, ISerializable
+{
+  credentialType: string;
+  platformAuthenticatorDataBase64: string;
+  platformAuthenticatorClientDataBase64: string;
+  platformAuthenticatorSignatureBase64: string;
+
+  constructor(
+    platformAuthenticatorDataBase64: string,
+    platformAuthenticatorClientDataBase64: string,
+    platformAuthenticatorSignatureBase64: string
+  ) {
+    this.credentialType = "PlatformAuthenticatorCredential";
+    this.platformAuthenticatorDataBase64 =
+      platformAuthenticatorDataBase64;
+    this.platformAuthenticatorClientDataBase64 =
+      platformAuthenticatorClientDataBase64;
+    this.platformAuthenticatorSignatureBase64 =
+      platformAuthenticatorSignatureBase64;
+  }
+
+  toDictionary(): Dictionary {
+    return {
+      credential_type: this.credentialType,
+      platform_authenticator_data_base64:
+        this.platformAuthenticatorDataBase64,
+      platform_authenticator_client_data_base64:
+        this.platformAuthenticatorClientDataBase64,
+      platform_authenticator_signature_base64:
+        this.platformAuthenticatorSignatureBase64,
+    };
+  }
+
+  fromDictionary(dict: Dictionary): void {
+    this.credentialType = dict["credential_type"] as string;
+    this.platformAuthenticatorDataBase64 = dict[
+      "platform_authenticator_data_base64"
+    ] as string;
+    this.platformAuthenticatorClientDataBase64 = dict[
+      "platform_authenticator_client_data_base64"
+    ] as string;
+    this.platformAuthenticatorSignatureBase64 = dict[
+      "platform_authenticator_signature_base64"
+    ] as string;
+  }
+
+  loadFromDisk(): void {
+    throw new Error("Method not implemented.");
+  }
+
+  saveToDisk(): void {
+    throw new Error("Method not implemented.");
+  }
+}
+
+export class GoogleOAuth2Credential
+  implements IGoogleOAuth2Credential, ISerializable
+{
+  credentialType: string;
+  googleOAuth2CredentialClientID: string;
+  googleOAuth2CredentialJWT: string;
+
+  constructor(
+    googleOAuth2CredentialClientID: string,
+    googleOAuth2CredentialJWT: string
+  ) {
+    this.credentialType = "GoogleOAuth2Credential";
+    this.googleOAuth2CredentialClientID =
+      googleOAuth2CredentialClientID;
+    this.googleOAuth2CredentialJWT = googleOAuth2CredentialJWT;
+  }
+
+  toDictionary(): Dictionary {
+    return {
+      credential_type: this.credentialType,
+      google_oauth2_credential_client_id:
+        this.googleOAuth2CredentialClientID,
+      google_oauth2_credential_jwt: this.googleOAuth2CredentialJWT,
+    };
+  }
+
+  fromDictionary(dict: Dictionary): void {
+    this.credentialType = dict["credential_type"] as string;
+    this.googleOAuth2CredentialClientID = dict[
+      "google_oauth2_credential_client_id"
+    ] as string;
+    this.googleOAuth2CredentialJWT = dict[
+      "google_oauth2_credential_jwt"
+    ] as string;
+  }
+
+  loadFromDisk(): void {
+    throw new Error("Method not implemented.");
+  }
+
+  saveToDisk(): void {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -1,16 +1,37 @@
 import { Dictionary } from "./Types";
 
+export interface IPlatformAuthenticatorCredential {
+  credentialType: string;
+  platformAuthenticatorDataBase64: string;
+  platformAuthenticatorClientDataBase64: string;
+  platformAuthenticatorSignatureBase64: string;
+}
+
+export interface IGoogleOAuth2Credential {
+  credentialType: string;
+  googleOAuth2CredentialClientID: string;
+  googleOAuth2CredentialJWT: string;
+}
+
 /**
  * The network layer identity of a SHARE network
  * participant.
  */
 export interface IIdentity {
   uniqueID?: string | undefined;
+
+  // ----- LEGACY -----
   platformAuthenticatorDataBase64?: string | undefined;
   platformAuthenticatorClientDataBase64?: string | undefined;
   platformAuthenticatorSignatureBase64?: string | undefined;
   googleOAuth2CredentialClientID?: string | undefined;
   googleOAuth2CredentialJWT?: string | undefined;
+
+  // ----- NEW -----
+  platformAuthenticatorCredential?:
+    | IPlatformAuthenticatorCredential
+    | undefined;
+  googleOAuth2Credential?: IGoogleOAuth2Credential | undefined;
 }
 
 /**
@@ -41,6 +62,7 @@ export interface ISerializable {
   loadFromDisk(): void;
   saveToDisk(): void;
   toDictionary(): Dictionary;
+  // eslint-disable-next-line no-unused-vars
   fromDictionary(dict: Dictionary): void;
 }
 
@@ -50,6 +72,7 @@ export interface ISerializable {
  */
 export interface IVDRSerializable {
   toVDRFormattedDictionary(): Dictionary;
+  // eslint-disable-next-line no-unused-vars
   fromVDRFormattedDictionary(entry: Dictionary): void;
 }
 

--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -1,5 +1,9 @@
 import { Dictionary } from "./Types";
 
+/*
+ * Secure enclave credential type for use
+ * with WebAuthn based identity verification.
+ */
 export interface IPlatformAuthenticatorCredential {
   credentialType: string;
   platformAuthenticatorDataBase64: string;
@@ -7,6 +11,10 @@ export interface IPlatformAuthenticatorCredential {
   platformAuthenticatorSignatureBase64: string;
 }
 
+/*
+ * Google OAuth2 credential type for use
+ * with one tap sign in with Google based identity verification.
+ */
 export interface IGoogleOAuth2Credential {
   credentialType: string;
   googleOAuth2CredentialClientID: string;
@@ -19,15 +27,12 @@ export interface IGoogleOAuth2Credential {
  */
 export interface IIdentity {
   uniqueID?: string | undefined;
-
-  // ----- LEGACY -----
+  // TODO(https://github.com/formless-eng/share/issues/1965):
+  // Deprecate top level platform authenticator credentials.
   platformAuthenticatorDataBase64?: string | undefined;
   platformAuthenticatorClientDataBase64?: string | undefined;
   platformAuthenticatorSignatureBase64?: string | undefined;
-  googleOAuth2CredentialClientID?: string | undefined;
-  googleOAuth2CredentialJWT?: string | undefined;
 
-  // ----- NEW -----
   platformAuthenticatorCredential?:
     | IPlatformAuthenticatorCredential
     | undefined;

--- a/src/test/Credential.test.ts
+++ b/src/test/Credential.test.ts
@@ -16,7 +16,7 @@ describe("PlatformAuthenticatorCredential", () => {
 
   it("should initialize with correct values", () => {
     expect(credential.credentialType).toBe(
-      "PlatformAuthenticatorCredential"
+      "platform_authenticator_credential"
     );
     expect(credential.platformAuthenticatorClientDataBase64).toBe(
       "test/platformAuthenticatorClientDataBase64"
@@ -31,7 +31,7 @@ describe("PlatformAuthenticatorCredential", () => {
 
   it("should serialize to dictionary with correct values", () => {
     expect(credential.toDictionary()).toEqual({
-      credential_type: "PlatformAuthenticatorCredential",
+      credential_type: "platform_authenticator_credential",
       platform_authenticator_data_base64:
         "test/platformAuthenticatorDataBase64",
       platform_authenticator_client_data_base64:
@@ -43,7 +43,7 @@ describe("PlatformAuthenticatorCredential", () => {
 
   it("should deserialize from dictionary with correct values", () => {
     credential.fromDictionary({
-      credential_type: "PlatformAuthenticatorCredential",
+      credential_type: "platform_authenticator_credential",
       platform_authenticator_data_base64:
         "test/platformAuthenticatorDataBase64",
       platform_authenticator_client_data_base64:
@@ -74,7 +74,9 @@ describe("GoogleOAuth2Credential", () => {
   });
 
   it("should initialize with correct values", () => {
-    expect(credential.credentialType).toBe("GoogleOAuth2Credential");
+    expect(credential.credentialType).toBe(
+      "google_oauth2_credential"
+    );
     expect(credential.googleOAuth2CredentialClientID).toBe(
       "test/googleOAuth2CredentialClientID"
     );
@@ -85,10 +87,28 @@ describe("GoogleOAuth2Credential", () => {
 
   it("should serialize to dictionary with correct values", () => {
     expect(credential.toDictionary()).toEqual({
-      credential_type: "GoogleOAuth2Credential",
+      credential_type: "google_oauth2_credential",
       google_oauth2_credential_client_id:
         "test/googleOAuth2CredentialClientID",
       google_oauth2_credential_jwt: "test/googleOAuth2CredentialJWT",
     });
+  });
+
+  it("should deserialize from dictionary with correct values", () => {
+    credential.fromDictionary({
+      credential_type: "google_oauth2_credential",
+      google_oauth2_credential_client_id:
+        "test/googleOAuth2CredentialClientID",
+      google_oauth2_credential_jwt: "test/googleOAuth2CredentialJWT",
+    });
+    expect(credential.credentialType).toBe(
+      "google_oauth2_credential"
+    );
+    expect(credential.googleOAuth2CredentialClientID).toBe(
+      "test/googleOAuth2CredentialClientID"
+    );
+    expect(credential.googleOAuth2CredentialJWT).toBe(
+      "test/googleOAuth2CredentialJWT"
+    );
   });
 });

--- a/src/test/Credential.test.ts
+++ b/src/test/Credential.test.ts
@@ -1,0 +1,94 @@
+import {
+  PlatformAuthenticatorCredential,
+  GoogleOAuth2Credential,
+} from "../lib/Credential";
+
+describe("PlatformAuthenticatorCredential", () => {
+  let credential: PlatformAuthenticatorCredential;
+
+  beforeEach(() => {
+    credential = new PlatformAuthenticatorCredential(
+      "test/platformAuthenticatorDataBase64",
+      "test/platformAuthenticatorClientDataBase64",
+      "test/platformAuthenticatorSignatureBase64"
+    );
+  });
+
+  it("should initialize with correct values", () => {
+    expect(credential.credentialType).toBe(
+      "PlatformAuthenticatorCredential"
+    );
+    expect(credential.platformAuthenticatorClientDataBase64).toBe(
+      "test/platformAuthenticatorClientDataBase64"
+    );
+    expect(credential.platformAuthenticatorDataBase64).toBe(
+      "test/platformAuthenticatorDataBase64"
+    );
+    expect(credential.platformAuthenticatorSignatureBase64).toBe(
+      "test/platformAuthenticatorSignatureBase64"
+    );
+  });
+
+  it("should serialize to dictionary with correct values", () => {
+    expect(credential.toDictionary()).toEqual({
+      credential_type: "PlatformAuthenticatorCredential",
+      platform_authenticator_data_base64:
+        "test/platformAuthenticatorDataBase64",
+      platform_authenticator_client_data_base64:
+        "test/platformAuthenticatorClientDataBase64",
+      platform_authenticator_signature_base64:
+        "test/platformAuthenticatorSignatureBase64",
+    });
+  });
+
+  it("should deserialize from dictionary with correct values", () => {
+    credential.fromDictionary({
+      credential_type: "PlatformAuthenticatorCredential",
+      platform_authenticator_data_base64:
+        "test/platformAuthenticatorDataBase64",
+      platform_authenticator_client_data_base64:
+        "test/platformAuthenticatorClientDataBase64",
+      platform_authenticator_signature_base64:
+        "test/platformAuthenticatorSignatureBase64",
+    });
+    expect(credential.platformAuthenticatorClientDataBase64).toBe(
+      "test/platformAuthenticatorClientDataBase64"
+    );
+    expect(credential.platformAuthenticatorDataBase64).toBe(
+      "test/platformAuthenticatorDataBase64"
+    );
+    expect(credential.platformAuthenticatorSignatureBase64).toBe(
+      "test/platformAuthenticatorSignatureBase64"
+    );
+  });
+});
+
+describe("GoogleOAuth2Credential", () => {
+  let credential: GoogleOAuth2Credential;
+
+  beforeEach(() => {
+    credential = new GoogleOAuth2Credential(
+      "test/googleOAuth2CredentialClientID",
+      "test/googleOAuth2CredentialJWT"
+    );
+  });
+
+  it("should initialize with correct values", () => {
+    expect(credential.credentialType).toBe("GoogleOAuth2Credential");
+    expect(credential.googleOAuth2CredentialClientID).toBe(
+      "test/googleOAuth2CredentialClientID"
+    );
+    expect(credential.googleOAuth2CredentialJWT).toBe(
+      "test/googleOAuth2CredentialJWT"
+    );
+  });
+
+  it("should serialize to dictionary with correct values", () => {
+    expect(credential.toDictionary()).toEqual({
+      credential_type: "GoogleOAuth2Credential",
+      google_oauth2_credential_client_id:
+        "test/googleOAuth2CredentialClientID",
+      google_oauth2_credential_jwt: "test/googleOAuth2CredentialJWT",
+    });
+  });
+});


### PR DESCRIPTION
This PR adds Google OAuth2 credentials to `IIdentity` interface schema and encapsulates platform authenticator credentials within a Credential class.