### PR TITLE
Add verified to split interface

### DIFF
--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -126,6 +126,7 @@ export interface ISplit {
   percentage: number;
   unique_id: string | null;
   wallet_address: string;
+  verified_identity: boolean | null;
 }
 
 export interface ISplitsData {


### PR DESCRIPTION
This is needed for a verified icon on a split owner metadata chip.