### PR TITLE
Update schema based on example documents

### DIFF
--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -165,7 +165,10 @@ export interface IAsset {
     price_per_access_usd: number;
     price_per_license_usd: number;
     stakeholder_basis_points_dict?: Record<string, number>;
-    stakeholder_table_row_data?: Record<string, unknown>;
+    stakeholder_table_row_data?: Array<{
+      email: string;
+      percentage: number;
+    }>;
     supports_licensing: boolean;
     transaction_hash?: string;
     type: string;

--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -113,35 +113,51 @@ export interface IVDRSerializable {
 export interface IAsset {
   asset_title: string;
   asset_type: string;
+
   audio_analysis: {
     embedding_mert_v1_330M_1024D_normalized_mean_pooled: unknown;
     genre: string;
   } | null;
+
   blockchain: number;
   cloud_function_endpoint: string;
   contract_address: string;
   count_transactions: number;
   creator_address: string;
   creator_name: string;
+
   deployment_metadata: {
     contracts: any[];
     grant_ttl_seconds: number;
-    price_per_access_usd: number;
+
     metadata: {
-      absolute_expiration: number;
-      preview: DDNContractContentMetadata;
+      absolute_expiration: number | string;
       grant: DDNContractContentMetadata;
+      preview: DDNContractContentMetadata;
+      [key: string]: unknown;
     };
+
+    price_per_access_usd: number;
     [key: string]: unknown;
   };
+
   direct_view_count: number;
   enable_public_listing: boolean;
   hidden: boolean;
   id: string;
   media_url: string | null;
+
   metadata: {
-    absolute_expiration: number;
+    absolute_expiration: number | string;
+    access_grant_ttl_seconds?: number;
+    asset_description?: string;
+    asset_title?: string;
     asset_type: string;
+    blockchain_id?: number;
+    cloud_function_endpoint?: string;
+    community_splits_quantity?: number;
+    contract_address?: string;
+    creator_name?: string;
     grant: DDNContractContentMetadata;
     grant_ttl_seconds: number;
     json_rpc: string;
@@ -149,23 +165,36 @@ export interface IAsset {
     media_url: string;
     name: string;
     network_id: number;
+    PFA: {
+      contract_address: string;
+    } | null;
     preview: DDNContractContentMetadata;
     price_per_access_usd: number;
     price_per_license_usd: number;
+    stakeholder_basis_points_dict?: Record<string, number>;
+    stakeholder_table_row_data?: Record<string, unknown>;
     supports_licensing: boolean;
+    transaction_hash?: string;
     type: string;
   };
+
   name: string;
   network_id: number;
+
   PFA: {
     contract_address: string;
   } | null;
+
   play_count: number;
   splits: DDNContractSplitsMetadata | null;
-  timestamp: {
-    _seconds: number;
-    _nanoseconds: number;
-  };
+
+  timestamp:
+    | string
+    | {
+        _seconds: number;
+        _nanoseconds: number;
+      };
+
   type: string;
   unique_id: string;
 }

--- a/src/lib/Interfaces.ts
+++ b/src/lib/Interfaces.ts
@@ -113,40 +113,33 @@ export interface IVDRSerializable {
 export interface IAsset {
   asset_title: string;
   asset_type: string;
-
   audio_analysis: {
     embedding_mert_v1_330M_1024D_normalized_mean_pooled: unknown;
     genre: string;
   } | null;
-
   blockchain: number;
   cloud_function_endpoint: string;
   contract_address: string;
   count_transactions: number;
   creator_address: string;
   creator_name: string;
-
   deployment_metadata: {
     contracts: any[];
     grant_ttl_seconds: number;
-
     metadata: {
       absolute_expiration: number | string;
       grant: DDNContractContentMetadata;
       preview: DDNContractContentMetadata;
       [key: string]: unknown;
     };
-
     price_per_access_usd: number;
     [key: string]: unknown;
   };
-
   direct_view_count: number;
   enable_public_listing: boolean;
   hidden: boolean;
   id: string;
   media_url: string | null;
-
   metadata: {
     absolute_expiration: number | string;
     access_grant_ttl_seconds?: number;
@@ -177,24 +170,19 @@ export interface IAsset {
     transaction_hash?: string;
     type: string;
   };
-
   name: string;
   network_id: number;
-
   PFA: {
     contract_address: string;
   } | null;
-
   play_count: number;
   splits: DDNContractSplitsMetadata | null;
-
   timestamp:
     | string
     | {
         _seconds: number;
         _nanoseconds: number;
       };
-
   type: string;
   unique_id: string;
 }

--- a/src/lib/Types.ts
+++ b/src/lib/Types.ts
@@ -35,6 +35,10 @@ export type DDNContractSplitsMetadata = {
   split_contract_address: string;
   split_contract_type: string;
   splits_limit_per_unique_id: number;
+  split_contract_version?: string;
+  splits_recipient_requirements?: {
+    content_purchase?: boolean;
+  };
 };
 
 export type DDNContractNFTVerificationMetadata = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates core schema types to match example documents and improve flexibility.
> 
> - Widens `absolute_expiration` and `timestamp` to accept `string` or structured values
> - Adds optional asset `metadata` fields (e.g., `asset_description`, `asset_title`, `blockchain_id`, `cloud_function_endpoint`, `contract_address`, `creator_name`, `community_splits_quantity`, `PFA`, `stakeholder_basis_points_dict`, `stakeholder_table_row_data`, `transaction_hash`)
> - Allows extra keys via index signatures in `deployment_metadata.metadata`
> - Extends `DDNContractSplitsMetadata` with optional `split_contract_version` and `splits_recipient_requirements.content_purchase`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 717b556b521f5e3d73d927d769dfc837db0f89b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->